### PR TITLE
Add shared data models

### DIFF
--- a/news_kg/models.py
+++ b/news_kg/models.py
@@ -3,10 +3,12 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict
 
 
+# Stub — fields to be added when temporal enrichment is implemented.
 class TemporalAnnotation(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+# Stub — fields to be added when entity enrichment is implemented.
 class EntityAnnotation(BaseModel):
     model_config = ConfigDict(frozen=True)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 import pytest
+from pydantic import ValidationError
 
 from news_kg.models import Article, EntityAnnotation, TemporalAnnotation
 
@@ -16,6 +17,7 @@ def make_article(**kwargs):
 def test_article_construction():
     article = make_article()
     assert article.text == "Some article text."
+    assert article.date == datetime(2024, 1, 1, tzinfo=UTC)
     assert article.temporal is None
     assert article.entities is None
 
@@ -31,20 +33,40 @@ def test_article_with_enrichments():
 
 def test_article_is_frozen():
     article = make_article()
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         article.text = "changed"
 
 
-def test_article_json_round_trip():
+def test_temporal_annotation_is_frozen():
+    annotation = TemporalAnnotation()
+    with pytest.raises(ValidationError):
+        annotation.x = 1  # type: ignore[attr-defined]
+
+
+def test_entity_annotation_is_frozen():
+    annotation = EntityAnnotation()
+    with pytest.raises(ValidationError):
+        annotation.x = 1  # type: ignore[attr-defined]
+
+
+def test_article_dict_round_trip():
     article = make_article()
     restored = Article.model_validate(article.model_dump())
     assert restored == article
 
 
-def test_article_json_round_trip_with_enrichments():
+def test_article_dict_round_trip_with_enrichments():
     article = make_article(
         temporal=TemporalAnnotation(),
         entities=EntityAnnotation(),
     )
     restored = Article.model_validate(article.model_dump())
     assert restored == article
+
+
+def test_article_missing_required_fields():
+    with pytest.raises(ValidationError):
+        Article(text="only text")  # missing date
+
+    with pytest.raises(ValidationError):
+        Article(date=datetime(2024, 1, 1, tzinfo=UTC))  # missing text


### PR DESCRIPTION
## Summary

- Adds `news_kg/models.py` with stub `TemporalAnnotation` and `EntityAnnotation` models and a generic `Article` model (`text`, `date`, optional enrichment fields)
- All models are frozen Pydantic models
- Adds tests for construction, frozen enforcement, and JSON round-trip

Closes #2