### PR TITLE
Add FilesystemStore and url field to Article

### DIFF
--- a/news_kg/models.py
+++ b/news_kg/models.py
@@ -18,5 +18,6 @@ class Article(BaseModel):
 
     text: str
     date: datetime
+    url: str
     temporal: TemporalAnnotation | None = None
     entities: EntityAnnotation | None = None

--- a/news_kg/store.py
+++ b/news_kg/store.py
@@ -1,0 +1,50 @@
+import hashlib
+from collections.abc import Iterable
+from pathlib import Path
+
+from news_kg.models import Article
+
+
+def _article_id(url: str) -> str:
+    return hashlib.sha256(url.encode()).hexdigest()
+
+
+class FilesystemStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, article_id: str) -> Path:
+        return self.root / f"{article_id}.json"
+
+    def save(self, article: Article) -> str:
+        article_id = _article_id(article.url)
+        path = self._path(article_id)
+
+        if path.exists():
+            stored = Article.model_validate_json(path.read_text())
+            enrichments = {
+                "temporal": article.temporal,
+                "entities": article.entities,
+            }
+            merged = stored.model_copy(
+                update={k: v for k, v in enrichments.items() if v is not None}
+            )
+            path.write_text(merged.model_dump_json())
+        else:
+            path.write_text(article.model_dump_json())
+
+        return article_id
+
+    def exists(self, article_id: str) -> bool:
+        return self._path(article_id).exists()
+
+    def load(self, article_id: str) -> Article:
+        path = self._path(article_id)
+        if not path.exists():
+            raise KeyError(f"Article not found: {article_id}")
+        return Article.model_validate_json(path.read_text())
+
+    def all(self) -> Iterable[Article]:
+        for path in self.root.glob("*.json"):
+            yield Article.model_validate_json(path.read_text())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ def make_article(**kwargs):
     defaults = {
         "text": "Some article text.",
         "date": datetime(2024, 1, 1, tzinfo=UTC),
+        "url": "https://example.com/article",
     }
     return Article(**{**defaults, **kwargs})
 
@@ -18,6 +19,7 @@ def test_article_construction():
     article = make_article()
     assert article.text == "Some article text."
     assert article.date == datetime(2024, 1, 1, tzinfo=UTC)
+    assert article.url == "https://example.com/article"
     assert article.temporal is None
     assert article.entities is None
 
@@ -66,7 +68,12 @@ def test_article_dict_round_trip_with_enrichments():
 
 def test_article_missing_required_fields():
     with pytest.raises(ValidationError):
-        Article(text="only text")  # missing date
+        Article(text="only text", url="https://example.com")  # missing date
 
     with pytest.raises(ValidationError):
-        Article(date=datetime(2024, 1, 1, tzinfo=UTC))  # missing text
+        Article(  # missing text
+            date=datetime(2024, 1, 1, tzinfo=UTC), url="https://example.com"
+        )
+
+    with pytest.raises(ValidationError):
+        Article(text="only text", date=datetime(2024, 1, 1, tzinfo=UTC))  # missing url

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,108 @@
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from news_kg.models import Article, EntityAnnotation, TemporalAnnotation
+from news_kg.store import FilesystemStore
+
+
+def make_article(**kwargs) -> Article:
+    defaults = {
+        "text": "Some article text.",
+        "date": datetime(2024, 1, 1, tzinfo=UTC),
+        "url": "https://example.com/article",
+    }
+    return Article(**{**defaults, **kwargs})
+
+
+def article_id(url: str) -> str:
+    return hashlib.sha256(url.encode()).hexdigest()
+
+
+def test_store_creates_directory(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    assert not root.exists()
+    FilesystemStore(root)
+    assert root.exists()
+
+
+def test_save_and_load_round_trip(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    article = make_article()
+    aid = store.save(article)
+    loaded = store.load(aid)
+    assert loaded == article
+
+
+def test_exists_before_and_after_save(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    article = make_article()
+    aid = article_id(article.url)
+    assert not store.exists(aid)
+    store.save(article)
+    assert store.exists(aid)
+
+
+def test_all_returns_all_articles(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    articles = [
+        make_article(url="https://example.com/1"),
+        make_article(url="https://example.com/2"),
+        make_article(url="https://example.com/3"),
+    ]
+    for a in articles:
+        store.save(a)
+    result = list(store.all())
+    assert len(result) == 3
+    assert set(a.url for a in result) == {
+        "https://example.com/1",
+        "https://example.com/2",
+        "https://example.com/3",
+    }
+
+
+def test_load_missing_raises_key_error(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    with pytest.raises(KeyError):
+        store.load("nonexistent-id")
+
+
+def test_save_merges_enrichments(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    base = make_article()
+    aid = store.save(base)
+
+    enriched = make_article(
+        temporal=TemporalAnnotation(),
+        entities=EntityAnnotation(),
+    )
+    store.save(enriched)
+
+    loaded = store.load(aid)
+    assert loaded.text == base.text
+    assert loaded.date == base.date
+    assert loaded.url == base.url
+    assert loaded.temporal is not None
+    assert loaded.entities is not None
+
+
+def test_save_merge_preserves_existing_enrichments(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    first = make_article(temporal=TemporalAnnotation())
+    aid = store.save(first)
+
+    second = make_article(entities=EntityAnnotation())
+    store.save(second)
+
+    loaded = store.load(aid)
+    assert loaded.temporal is not None
+    assert loaded.entities is not None
+
+
+def test_save_returns_article_id(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path)
+    article = make_article()
+    aid = store.save(article)
+    assert aid == article_id(article.url)


### PR DESCRIPTION
## Summary

- Adds `url: str` as a required field on `Article` (stable identifier for storage keying)
- Implements `FilesystemStore` backed by SHA256-keyed JSON files under a configurable root directory
- `save` merges enrichment fields (`temporal`, `entities`) on re-save rather than overwriting base data, allowing annotations to accumulate across pipeline runs
- `exists`, `load`, and `all` provide presence checking, retrieval, and corpus iteration

Closes #3