### PR TITLE
Address review feedback on FilesystemStore

### DIFF
--- a/news_kg/store.py
+++ b/news_kg/store.py
@@ -1,5 +1,5 @@
 import hashlib
-from collections.abc import Iterable
+from collections.abc import Iterator
 from pathlib import Path
 
 from news_kg.models import Article
@@ -12,28 +12,15 @@ def _article_id(url: str) -> str:
 class FilesystemStore:
     def __init__(self, root: Path) -> None:
         self.root = root
-        self.root.mkdir(parents=True, exist_ok=True)
+        self._articles = root / "articles"
+        self._articles.mkdir(parents=True, exist_ok=True)
 
     def _path(self, article_id: str) -> Path:
-        return self.root / f"{article_id}.json"
+        return self._articles / f"{article_id}.json"
 
     def save(self, article: Article) -> str:
         article_id = _article_id(article.url)
-        path = self._path(article_id)
-
-        if path.exists():
-            stored = Article.model_validate_json(path.read_text())
-            enrichments = {
-                "temporal": article.temporal,
-                "entities": article.entities,
-            }
-            merged = stored.model_copy(
-                update={k: v for k, v in enrichments.items() if v is not None}
-            )
-            path.write_text(merged.model_dump_json())
-        else:
-            path.write_text(article.model_dump_json())
-
+        self._path(article_id).write_text(article.model_dump_json())
         return article_id
 
     def exists(self, article_id: str) -> bool:
@@ -45,6 +32,6 @@ class FilesystemStore:
             raise KeyError(f"Article not found: {article_id}")
         return Article.model_validate_json(path.read_text())
 
-    def all(self) -> Iterable[Article]:
-        for path in self.root.glob("*.json"):
+    def all(self) -> Iterator[Article]:
+        for path in self._articles.glob("*.json"):
             yield Article.model_validate_json(path.read_text())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from news_kg.models import Article
+
+
+@pytest.fixture
+def make_article():
+    def _make(**kwargs) -> Article:
+        defaults = {
+            "text": "Some article text.",
+            "date": datetime(2024, 1, 1, tzinfo=UTC),
+            "url": "https://example.com/article",
+        }
+        return Article(**{**defaults, **kwargs})
+
+    return _make

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,16 +6,7 @@ from pydantic import ValidationError
 from news_kg.models import Article, EntityAnnotation, TemporalAnnotation
 
 
-def make_article(**kwargs):
-    defaults = {
-        "text": "Some article text.",
-        "date": datetime(2024, 1, 1, tzinfo=UTC),
-        "url": "https://example.com/article",
-    }
-    return Article(**{**defaults, **kwargs})
-
-
-def test_article_construction():
+def test_article_construction(make_article):
     article = make_article()
     assert article.text == "Some article text."
     assert article.date == datetime(2024, 1, 1, tzinfo=UTC)
@@ -24,7 +15,7 @@ def test_article_construction():
     assert article.entities is None
 
 
-def test_article_with_enrichments():
+def test_article_with_enrichments(make_article):
     article = make_article(
         temporal=TemporalAnnotation(),
         entities=EntityAnnotation(),
@@ -33,7 +24,7 @@ def test_article_with_enrichments():
     assert article.entities is not None
 
 
-def test_article_is_frozen():
+def test_article_is_frozen(make_article):
     article = make_article()
     with pytest.raises(ValidationError):
         article.text = "changed"
@@ -51,13 +42,13 @@ def test_entity_annotation_is_frozen():
         annotation.x = 1  # type: ignore[attr-defined]
 
 
-def test_article_dict_round_trip():
+def test_article_dict_round_trip(make_article):
     article = make_article()
     restored = Article.model_validate(article.model_dump())
     assert restored == article
 
 
-def test_article_dict_round_trip_with_enrichments():
+def test_article_dict_round_trip_with_enrichments(make_article):
     article = make_article(
         temporal=TemporalAnnotation(),
         entities=EntityAnnotation(),

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,34 +1,19 @@
-import hashlib
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from news_kg.models import Article, EntityAnnotation, TemporalAnnotation
-from news_kg.store import FilesystemStore
-
-
-def make_article(**kwargs) -> Article:
-    defaults = {
-        "text": "Some article text.",
-        "date": datetime(2024, 1, 1, tzinfo=UTC),
-        "url": "https://example.com/article",
-    }
-    return Article(**{**defaults, **kwargs})
-
-
-def article_id(url: str) -> str:
-    return hashlib.sha256(url.encode()).hexdigest()
+from news_kg.models import EntityAnnotation, TemporalAnnotation
+from news_kg.store import FilesystemStore, _article_id
 
 
 def test_store_creates_directory(tmp_path: Path) -> None:
     root = tmp_path / "store"
     assert not root.exists()
     FilesystemStore(root)
-    assert root.exists()
+    assert (root / "articles").exists()
 
 
-def test_save_and_load_round_trip(tmp_path: Path) -> None:
+def test_save_and_load_round_trip(tmp_path: Path, make_article) -> None:
     store = FilesystemStore(tmp_path)
     article = make_article()
     aid = store.save(article)
@@ -36,16 +21,16 @@ def test_save_and_load_round_trip(tmp_path: Path) -> None:
     assert loaded == article
 
 
-def test_exists_before_and_after_save(tmp_path: Path) -> None:
+def test_exists_before_and_after_save(tmp_path: Path, make_article) -> None:
     store = FilesystemStore(tmp_path)
     article = make_article()
-    aid = article_id(article.url)
+    aid = _article_id(article.url)
     assert not store.exists(aid)
     store.save(article)
     assert store.exists(aid)
 
 
-def test_all_returns_all_articles(tmp_path: Path) -> None:
+def test_all_returns_all_articles(tmp_path: Path, make_article) -> None:
     store = FilesystemStore(tmp_path)
     articles = [
         make_article(url="https://example.com/1"),
@@ -69,40 +54,20 @@ def test_load_missing_raises_key_error(tmp_path: Path) -> None:
         store.load("nonexistent-id")
 
 
-def test_save_merges_enrichments(tmp_path: Path) -> None:
+def test_save_overwrites_existing(tmp_path: Path, make_article) -> None:
     store = FilesystemStore(tmp_path)
-    base = make_article()
-    aid = store.save(base)
+    original = make_article()
+    aid = store.save(original)
 
-    enriched = make_article(
-        temporal=TemporalAnnotation(),
-        entities=EntityAnnotation(),
-    )
-    store.save(enriched)
+    updated = make_article(temporal=TemporalAnnotation(), entities=EntityAnnotation())
+    store.save(updated)
 
     loaded = store.load(aid)
-    assert loaded.text == base.text
-    assert loaded.date == base.date
-    assert loaded.url == base.url
-    assert loaded.temporal is not None
-    assert loaded.entities is not None
+    assert loaded == updated
 
 
-def test_save_merge_preserves_existing_enrichments(tmp_path: Path) -> None:
-    store = FilesystemStore(tmp_path)
-    first = make_article(temporal=TemporalAnnotation())
-    aid = store.save(first)
-
-    second = make_article(entities=EntityAnnotation())
-    store.save(second)
-
-    loaded = store.load(aid)
-    assert loaded.temporal is not None
-    assert loaded.entities is not None
-
-
-def test_save_returns_article_id(tmp_path: Path) -> None:
+def test_save_returns_article_id(tmp_path: Path, make_article) -> None:
     store = FilesystemStore(tmp_path)
     article = make_article()
     aid = store.save(article)
-    assert aid == article_id(article.url)
+    assert aid == _article_id(article.url)


### PR DESCRIPTION
## Summary

Follow-up to #12. These changes were agreed during review but not pushed before merge.

- Remove merge-on-re-save logic — `save` now always overwrites; accumulating enrichments across pipeline stages is the caller's responsibility
- Write articles under `root/articles/` subdirectory so non-Article JSON in the root can't corrupt `all()` iteration
- Fix `all()` return type to `Iterator[Article]` (more precise for a generator)
- Move `make_article` to `conftest.py`, removing duplication across test files
- Remove reimplemented `article_id` helper in tests; import `_article_id` directly from `news_kg.store`